### PR TITLE
miopenConvolutionFwdAlgoStaticCompiledGEMM undeclared

### DIFF
--- a/src/backend/op_convolution_miopen.cc
+++ b/src/backend/op_convolution_miopen.cc
@@ -21,7 +21,6 @@ static const char * to_miopen_fwd_algo_name(miopenConvFwdAlgorithm_t fwd_algo){
         ALGO_CASE_STR(miopenConvolutionFwdAlgoFFT);
         ALGO_CASE_STR(miopenConvolutionFwdAlgoWinograd);
         ALGO_CASE_STR(miopenConvolutionFwdAlgoImplicitGEMM);
-        ALGO_CASE_STR(miopenConvolutionFwdAlgoStaticCompiledGEMM);
         default:
             return "N/A";
         break;


### PR DESCRIPTION
When attempting to build op_driver for miopen the following error is received `/workspace/miopen_cudnn_ops/src/backend/op_convolution_miopen.cc:24:23: error: use of undeclared identifier 'miopenConvolutionFwdAlgoStaticCompiledGEMM'; did you mean 'miopenConvolutionFwdAlgoImplicitGEMM'?
        ALGO_CASE_STR(miopenConvolutionFwdAlgoStaticCompiledGEMM);`

I can't find where `miopenConvolutionFwdAlgoStaticCompiledGEMM` is declared at all in miopen.  The logical step appears to be removing it from miopen's forward algorithms.