### PR TITLE
rnn support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,9 @@ list(APPEND backend_src
             src/backend/math.cc
             src/backend/backend.cc
             src/backend/operator.cc
-            src/backend/op_convolution.cc )
+            src/backend/op_convolution.cc
+            src/backend/op_rnn.cc)
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 ")
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${CMAKE_CURRENT_LIST_DIR}/src/backend ")
@@ -53,8 +55,9 @@ if(WITH_MIOPEN)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LD_FLAGS}")
 
     list(APPEND backend_src
-                src/backend/backend_miopen.cc
-                src/backend/op_convolution_miopen.cc )
+                "./src/backend/backend_miopen.cc"
+                "./src/backend/op_convolution_miopen.cc"
+                "./src/backend/op_rnn_miopen.cc")
 
 elseif(WITH_CUDNN)
     message(STATUS "compile on cudnn, nv platform")
@@ -65,13 +68,15 @@ elseif(WITH_CUDNN)
     message(STATUS "using cuda in path:${CUDA_HOME}")
     set(CMAKE_CXX_COMPILER  ${CUDA_HOME}/bin/nvcc)
     add_definitions(-DWITH_CUDNN)
+
+    # optimizations
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -O3 -Wall -Wno-literal-suffix")
 
     add_prefix(CMAKE_CXX_FLAGS "-Xcompiler ")
     #message(STATUS "### CMAKE_CXX_FLAGS:${CMAKE_CXX_FLAGS}")
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gencode arch=compute_70,code=compute_70 \
-                -gencode arch=compute_61,code=compute_61 -gencode arch=compute_60,code=compute_60")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -gencode arch=compute_90,code=compute_90 \
+        -gencode arch=compute_80,code=compute_80 ")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -ccbin g++ ")
 
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lcudnn -lcublas -lcuda")
@@ -81,8 +86,9 @@ elseif(WITH_CUDNN)
     #message(STATUS "### LD_FLAGS:${LD_FLAGS}")
 
     list(APPEND backend_src
-                src/backend/backend_cudnn.cc
-                src/backend/op_convolution_cudnn.cc )
+                "./src/backend/backend_cudnn.cc"
+                "./src/backend/op_convolution_cudnn.cc"
+                "./src/backend/op_rnn_cudnn.cc")
 else()
     message(FATAL "unknown platform.")
 endif()
@@ -99,4 +105,4 @@ function(op_exe TARGET)
     target_link_libraries(${TARGET} backend_lib ${op_exe_DEPS} m)
 endfunction()
 
-op_exe(op_driver SRCS src/executable/op_driver.cc)
+op_exe(op_driver SRCS "./src/executable/op_driver.cc")

--- a/build.sh
+++ b/build.sh
@@ -22,5 +22,5 @@ echo $CMAKE_BACKEND
 
 rm -rf build
 mkdir build && cd build
-cmake $CMAKE_BACKEND ../ || exit 1
+cmake -DCMAKE_BUILD_TYPE=Debug $CMAKE_BACKEND ../ || exit 1
 make -j`nproc`

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+rm -rf build
+./build.sh cudnn

--- a/src/backend/backend_cudnn.cc
+++ b/src/backend/backend_cudnn.cc
@@ -28,7 +28,6 @@ device_cuda::device_cuda(int dev_id){
         dump_dev_prop(&cuda_prop, i);
     }
 
-    
     cudaStream_t q;
     CHECK_CUDA(cudaSetDevice(dev_id));
     CHECK_CUDA(cudaStreamCreate(&q));
@@ -107,7 +106,7 @@ void device_cuda::device_timer_destroy(device_timer_t * dt){
         return;
     delete (device_timer_cuda*)dt;
 }
-tensor_t * device_cuda::tensor_create(size_t * dims, size_t n_dim, 
+tensor_t * device_cuda::tensor_create(size_t * dims, size_t n_dim,
         tensor_data_type data_type, tensor_layout layout){
 
     if(n_dim == 1 && layout == TENSOR_LAYOUT_1D){
@@ -148,7 +147,7 @@ tensor_t * device_cuda::tensor_create(size_t * dims, size_t n_dim,
 }
 
 #if 0
-tensor_t * device_cuda::filter_create(size_t * dims, size_t n_dim, 
+tensor_t * device_cuda::filter_create(size_t * dims, size_t n_dim,
         tensor_data_type data_type, tensor_layout layout){
     if(n_dim == 1 && layout == TENSOR_LAYOUT_1D){
         //void* ptr;
@@ -169,7 +168,7 @@ tensor_t * device_cuda::filter_create(size_t * dims, size_t n_dim,
     cudnnFilterDescriptor_t desc;
     CHECK_CUDNN(cudnnCreateFilterDescriptor(&desc));
     CHECK_CUDNN(cudnnSetFilter4dDescriptor(desc, to_cudnn_data_type(data_type),
-				to_cudnn_layout(layout), dims[0], dims[1], dims[2], dims[3]));
+                to_cudnn_layout(layout), dims[0], dims[1], dims[2], dims[3]));
 
     //void* ptr;
     //CHECK_CUDA(cudaMalloc(&ptr, dims[0]*dims[1]*dims[2]*dims[3]*data_type_unit(data_type)));
@@ -239,7 +238,7 @@ pooling_desc_t * device_cuda::pooling_desc_create(int * kernel, int * stride, in
     CHECK_CUDNN(cudnnCreatePoolingDescriptor(&desc));
     CHECK_CUDNN(cudnnSetPooling2dDescriptor(desc, pool_mode, CUDNN_PROPAGATE_NAN,
         kernel[0], kernel[1], padding[0], padding[1], stride[0], stride[1]));
-    
+
     pooling_desc_t *pooling_desc = new pooling_desc_t;
     pooling_desc->mode = mode;
     pooling_desc->n_dims = 2;
@@ -287,10 +286,10 @@ convolution_desc_t * device_cuda::convolution_desc_create(convolution_mode mode,
     CHECK_CUDNN(cudnnSetConvolutionNdDescriptor(desc, n_dims,
             padding, stride, dilation, to_cudnn_convolution_mode(mode), to_cudnn_data_type(dt)));
 #else
-	assert(n_dims == 2);
+    assert(n_dims == 2);
     CHECK_CUDNN(cudnnSetConvolution2dDescriptor(desc, padding[0], padding[1],
-				stride[0], stride[1], dilation[0], dilation[1],
-				to_cudnn_convolution_mode(mode), to_cudnn_data_type(dt)));
+                stride[0], stride[1], dilation[0], dilation[1],
+                to_cudnn_convolution_mode(mode), to_cudnn_data_type(dt)));
 #endif
 
 
@@ -301,7 +300,7 @@ convolution_desc_t * device_cuda::convolution_desc_create(convolution_mode mode,
 #endif
 
     if(groups != 1)
-		CHECK_CUDNN(cudnnSetConvolutionGroupCount(desc, groups));
+        CHECK_CUDNN(cudnnSetConvolutionGroupCount(desc, groups));
 
     convolution_desc_t * conv_desc = new convolution_desc_t;
     conv_desc->mode = mode;
@@ -330,8 +329,8 @@ convolution_desc_t * device_cuda::convolution_desc_create(convolution_mode mode,
         CHECK_CUDNN(cudnnCreateConvolutionDescriptor(&desc_wrw));
 
         CHECK_CUDNN(cudnnSetConvolution2dDescriptor(desc_wrw, padding[0], padding[1],
-				stride[0], stride[1], dilation[0], dilation[1],
-				CUDNN_CROSS_CORRELATION, CUDNN_DATA_FLOAT));
+                stride[0], stride[1], dilation[0], dilation[1],
+                CUDNN_CROSS_CORRELATION, CUDNN_DATA_FLOAT));
 #ifndef OP_CUDNN_FP16_NO_TENSORCORE
         if(dt == TENSOR_DT_HALF){
             CHECK_CUDNN(cudnnSetConvolutionMathType(desc_wrw, CUDNN_TENSOR_OP_MATH));
@@ -351,6 +350,16 @@ void device_cuda::convolution_desc_destroy(convolution_desc_t * conv_desc)
     if(conv_desc->desc_wrw)
         CHECK_CUDNN(cudnnDestroyConvolutionDescriptor((cudnnConvolutionDescriptor_t)conv_desc->desc_wrw));
     delete conv_desc;
+}
+rnn_desc_t * device_cuda::rnn_desc_create()
+{
+    rnn_desc_t * rnn_desc = new rnn_desc_t;
+
+    return rnn_desc;
+}
+void device_cuda::rnn_desc_destroy(rnn_desc_t * rnn_desc)
+{
+    delete rnn_desc;
 }
 
 void dump_cudnn_convolution_desc(const cudnnConvolutionDescriptor_t conv_desc){
@@ -377,7 +386,7 @@ void dump_cudnn_tensor_desc(const cudnnTensorDescriptor_t tensor_desc){
     int n,c,h,w;
     int n_stride, c_stride, h_stride, w_stride;
     cudnnDataType_t dt;
-    CHECK_CUDNN(cudnnGetTensor4dDescriptor(tensor_desc, &dt, &n, &c, &h, &w, 
+    CHECK_CUDNN(cudnnGetTensor4dDescriptor(tensor_desc, &dt, &n, &c, &h, &w,
         &n_stride, &c_stride, &h_stride, &w_stride));
     std::cout<<"<tensor desc> dt:"<<dt<<", n:"<<n<<", c:"<<c<<", h:"<<h<<", w:"<<w<<
         ", n_stride:"<<n_stride<<", c_stride:"<<c_stride<<", h_stride:"<<h_stride<<", w_stride:"<<w_stride<<std::endl;

--- a/src/backend/op_convolution.cc
+++ b/src/backend/op_convolution.cc
@@ -69,7 +69,7 @@ void op_convolution::forward(){
 }
 
 void op_convolution::backward(){
-    
+
 }
 void op_convolution::backward_data(){
 

--- a/src/backend/op_rnn.cc
+++ b/src/backend/op_rnn.cc
@@ -1,0 +1,7 @@
+#include "operator.hpp"
+
+void op_rnn::forward(){}
+void op_rnn::backward(){}
+void op_rnn::backward_data(){}
+void op_rnn::backward_filter(){}
+

--- a/src/backend/op_rnn_cudnn.cc
+++ b/src/backend/op_rnn_cudnn.cc
@@ -18,13 +18,8 @@ void print_info(const std::string& str1,
     std::cout << std::endl;
 }
 
-void op_rnn_cudnn::tune_op(){}
-void op_rnn_cudnn::forward()
+void op_rnn_cudnn::tune_op()
 {
-    float timeForward = 0.0;
-    float timeBackwardData = 0.0;
-    float timeBackwardWeights = 0.0;
-
     if (dataType == CUDNN_DATA_FLOAT)
     {
         rnn = new RNN_IMPL<float>();
@@ -49,11 +44,6 @@ void op_rnn_cudnn::forward()
 
         rnn->init();
         rnn->validate();
-        timeForward = rnn->forward();
-        timeBackwardData = rnn->backward_data();
-        timeBackwardWeights = rnn->backward_filter();
-
-        delete rnn;
     }
     else if (dataType == CUDNN_DATA_HALF)
     {
@@ -79,29 +69,60 @@ void op_rnn_cudnn::forward()
 
         rnnfp16->init();
         rnnfp16->validate();
-        timeForward = rnnfp16->forward();
-        timeBackwardData = rnnfp16->backward_data();
-        timeBackwardWeights = rnnfp16->backward_filter();
-
-        delete rnnfp16;
     }
-
-    // display the measurements
-    std::cout << std::endl;
-    print_info("Results");
-    print_info("timeForward"        , timeForward, "ms");
-    print_info("timeBackwardData"   , timeBackwardData, "ms");
-    print_info("timeBackwardWeights", timeBackwardWeights, "ms");
 }
 
-void op_rnn_cudnn::backward_data(){}
-void op_rnn_cudnn::backward_filter(){}
+void op_rnn_cudnn::forward()
+{
+    if (dataType == CUDNN_DATA_FLOAT)
+    {
+        timeForward = rnn->forward();
+    }
+    else if (dataType == CUDNN_DATA_HALF)
+    {
+        timeForward = rnnfp16->forward();
+    }
+}
+
+void op_rnn_cudnn::backward_data()
+{
+    if (dataType == CUDNN_DATA_FLOAT)
+    {
+        timeBackwardData = rnn->backward_data();
+    }
+    else if (dataType == CUDNN_DATA_HALF)
+    {
+        timeBackwardData = rnnfp16->backward_data();
+    }
+}
+
+void op_rnn_cudnn::backward_filter()
+{
+    if (dataType == CUDNN_DATA_FLOAT)
+    {
+        timeBackwardWeights = rnn->backward_filter();
+    }
+    else if (dataType == CUDNN_DATA_HALF)
+    {
+        timeBackwardWeights = rnnfp16->backward_filter();
+    }
+}
+
 void op_rnn_cudnn::backward(){}
 
 std::string op_rnn_cudnn::get_fwd_algo_name() { return ""; }
 std::string op_rnn_cudnn::get_bwd_data_name() { return ""; }
 std::string op_rnn_cudnn::get_bwd_filter_name() { return ""; }
 
-void op_rnn_cudnn::print_fwd_time(const float kernel_average_time) {}
-void op_rnn_cudnn::print_bwd_time(const float kernel_average_time) {}
-void op_rnn_cudnn::print_wrw_time(const float kernel_average_time) {}
+void op_rnn_cudnn::print_fwd_time(const float kernel_average_time)
+{
+    print_info("timeForward"        , timeForward, "ms");
+}
+void op_rnn_cudnn::print_bwd_time(const float kernel_average_time)
+{
+    print_info("timeBackwardData"   , timeBackwardData, "ms");
+}
+void op_rnn_cudnn::print_wrw_time(const float kernel_average_time)
+{
+    print_info("timeBackwardWeights", timeBackwardWeights, "ms");
+}

--- a/src/backend/op_rnn_cudnn.cc
+++ b/src/backend/op_rnn_cudnn.cc
@@ -104,15 +104,33 @@ std::string op_rnn_cudnn::get_bwd_filter_name() { return ""; }
 
 void op_rnn_cudnn::print_fwd_time(const float kernel_average_time)
 {
-    std::cout << "GPU Kernel Time Forward RNN Elapsed: " << timeForward << " ms" << std::endl;
+    std::cout << std::left;
+    std::cout << std::setw(46);
+    std::cout << "GPU Kernel Time Forward RNN Elapsed: ";
+    std::cout << std::setw(7);
+    std::cout << std::setprecision(5);
+    std::cout << timeForward << " ms";
+    std::cout << std::endl;
 }
 void op_rnn_cudnn::print_bwd_time(const float kernel_average_time)
 {
-    std::cout << "GPU Kernel Time Backward Data RNN Elapsed: " << timeBackwardData << " ms" << std::endl;
+    std::cout << std::left;
+    std::cout << std::setw(46);
+    std::cout << "GPU Kernel Time Backward Data RNN Elapsed: ";
+    std::cout << std::setw(7);
+    std::cout << std::setprecision(5);
+    std::cout << timeBackwardData << "ms";
+    std::cout << std::endl;
 }
 void op_rnn_cudnn::print_wrw_time(const float kernel_average_time)
 {
-    std::cout << "GPU Kernel Time Backward Weights RNN Elapsed: " << timeBackwardWeights << " ms" << std::endl;
+    std::cout << std::left;
+    std::cout << std::setw(46);
+    std::cout << "GPU Kernel Time Backward Weights RNN Elapsed: ";
+    std::cout << std::setw(7);
+    std::cout << std::setprecision(5);
+    std::cout << timeBackwardWeights << "ms";
+    std::cout << std::endl;
 }
 
 /*/// reference MIOpenDriver output

--- a/src/backend/op_rnn_cudnn.cc
+++ b/src/backend/op_rnn_cudnn.cc
@@ -1,0 +1,107 @@
+#include "operator.hpp"
+#include <vector>
+#include <iostream>
+#include <iomanip>
+
+op_rnn_cudnn::op_rnn_cudnn(void * desc) : op_rnn(desc){}
+op_rnn_cudnn::~op_rnn_cudnn(){}
+
+void print_info(const std::string& str1,
+    const double& value = -1.0, const std::string& str2 = "")
+{
+    std::cout << std::right << std::setw(20) << str1  << ": ";
+    if (value != -1)
+    {
+        std::cout << std::right << std::setw(8) << std::setprecision(4) << value << " ";
+        std::cout << std::left  << std::setw(30) << str2  << " ";
+    }
+    std::cout << std::endl;
+}
+
+void op_rnn_cudnn::tune_op(){}
+void op_rnn_cudnn::forward()
+{
+    float timeForward = 0.0;
+    float timeBackwardData = 0.0;
+    float timeBackwardWeights = 0.0;
+
+    if (dataType == CUDNN_DATA_FLOAT)
+    {
+        rnn = new RNN_IMPL<float>();
+
+        rnn->dataType            = dataType;
+        rnn->seqLength           = seqLength;
+        rnn->numLayers           = numLayers;
+        rnn->inputSize           = inputSize;
+        rnn->hiddenSize          = hiddenSize;
+        rnn->outputSize          = outputSize;
+        rnn->miniBatch           = miniBatch;
+        rnn->rnnInputMode        = rnnInputMode;
+        rnn->recurrencePattern   = recurrencePattern;
+        rnn->rnnCellMode         = rnnCellMode;
+        rnn->rnnBiasMode         = rnnBiasMode;
+        rnn->rnnAlgorithm        = rnnAlgorithm;
+        rnn->mathPrecision       = mathPrecision;
+        rnn->mathType            = mathType;
+        rnn->dropout             = dropout;
+        rnn->warmupIterations    = warmupIterations;
+        rnn->measureIterations   = measureIterations;
+
+        rnn->init();
+        rnn->validate();
+        timeForward = rnn->forward();
+        timeBackwardData = rnn->backward_data();
+        timeBackwardWeights = rnn->backward_filter();
+
+        delete rnn;
+    }
+    else if (dataType == CUDNN_DATA_HALF)
+    {
+        rnnfp16 = new RNN_IMPL<half>();
+
+        rnnfp16->dataType            = dataType;
+        rnnfp16->seqLength           = seqLength;
+        rnnfp16->numLayers           = numLayers;
+        rnnfp16->inputSize           = inputSize;
+        rnnfp16->hiddenSize          = hiddenSize;
+        rnnfp16->outputSize          = outputSize;
+        rnnfp16->miniBatch           = miniBatch;
+        rnnfp16->rnnInputMode        = rnnInputMode;
+        rnnfp16->recurrencePattern   = recurrencePattern;
+        rnnfp16->rnnCellMode         = rnnCellMode;
+        rnnfp16->rnnBiasMode         = rnnBiasMode;
+        rnnfp16->rnnAlgorithm        = rnnAlgorithm;
+        rnnfp16->mathPrecision       = mathPrecision;
+        rnnfp16->mathType            = mathType;
+        rnnfp16->dropout             = dropout;
+        rnnfp16->warmupIterations    = warmupIterations;
+        rnnfp16->measureIterations   = measureIterations;
+
+        rnnfp16->init();
+        rnnfp16->validate();
+        timeForward = rnnfp16->forward();
+        timeBackwardData = rnnfp16->backward_data();
+        timeBackwardWeights = rnnfp16->backward_filter();
+
+        delete rnnfp16;
+    }
+
+    // display the measurements
+    std::cout << std::endl;
+    print_info("Results");
+    print_info("timeForward"        , timeForward, "ms");
+    print_info("timeBackwardData"   , timeBackwardData, "ms");
+    print_info("timeBackwardWeights", timeBackwardWeights, "ms");
+}
+
+void op_rnn_cudnn::backward_data(){}
+void op_rnn_cudnn::backward_filter(){}
+void op_rnn_cudnn::backward(){}
+
+std::string op_rnn_cudnn::get_fwd_algo_name() { return ""; }
+std::string op_rnn_cudnn::get_bwd_data_name() { return ""; }
+std::string op_rnn_cudnn::get_bwd_filter_name() { return ""; }
+
+void op_rnn_cudnn::print_fwd_time(const float kernel_average_time) {}
+void op_rnn_cudnn::print_bwd_time(const float kernel_average_time) {}
+void op_rnn_cudnn::print_wrw_time(const float kernel_average_time) {}

--- a/src/backend/op_rnn_cudnn.cc
+++ b/src/backend/op_rnn_cudnn.cc
@@ -6,18 +6,6 @@
 op_rnn_cudnn::op_rnn_cudnn(void * desc) : op_rnn(desc){}
 op_rnn_cudnn::~op_rnn_cudnn(){}
 
-void print_info(const std::string& str1,
-    const double& value = -1.0, const std::string& str2 = "")
-{
-    std::cout << std::right << std::setw(20) << str1  << ": ";
-    if (value != -1)
-    {
-        std::cout << std::right << std::setw(8) << std::setprecision(4) << value << " ";
-        std::cout << std::left  << std::setw(30) << str2  << " ";
-    }
-    std::cout << std::endl;
-}
-
 void op_rnn_cudnn::tune_op()
 {
     if (dataType == CUDNN_DATA_FLOAT)
@@ -116,13 +104,27 @@ std::string op_rnn_cudnn::get_bwd_filter_name() { return ""; }
 
 void op_rnn_cudnn::print_fwd_time(const float kernel_average_time)
 {
-    print_info("timeForward"        , timeForward, "ms");
+    std::cout << "GPU Kernel Time Forward RNN Elapsed: " << timeForward << " ms" << std::endl;
 }
 void op_rnn_cudnn::print_bwd_time(const float kernel_average_time)
 {
-    print_info("timeBackwardData"   , timeBackwardData, "ms");
+    std::cout << "GPU Kernel Time Backward Data RNN Elapsed: " << timeBackwardData << " ms" << std::endl;
 }
 void op_rnn_cudnn::print_wrw_time(const float kernel_average_time)
 {
-    print_info("timeBackwardWeights", timeBackwardWeights, "ms");
+    std::cout << "GPU Kernel Time Backward Weights RNN Elapsed: " << timeBackwardWeights << " ms" << std::endl;
 }
+
+/*/// reference MIOpenDriver output
+$ /opt/rocm-6.0.2/bin/MIOpenDriver rnn     -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 0 -t 1 -w 1 -V 0
+MIOpenDriver rnn -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 0 -t 1 -w 1 -V 0
+length of data sequence == 1 is short than time sequence == 32, padding the rest of data sequence with 224
+length of data sequence == 1 is short than time sequence == 32, padding the rest of data sequence with 224
+PRNG seed: 12345678
+GPU Kernel Time Forward RNN Elapsed: 0.000000 ms
+Wall-clock Time Forward RNN Elapsed: 4633.160645 ms
+GPU Kernel Time Backward Data RNN Elapsed: 0.000000 ms
+Wall-clock Time Backward Data RNN Elapsed: 161.234756 ms
+GPU Kernel Time Backward Weights RNN Elapsed: 0.000000 ms
+Wall-clock Time Backward Weights RNN Elapsed: 121.429344 ms
+//*///

--- a/src/backend/op_rnn_miopen.cc
+++ b/src/backend/op_rnn_miopen.cc
@@ -1,0 +1,19 @@
+#include "operator.hpp"
+#include "backend.hpp"
+
+op_rnn_miopen::op_rnn_miopen(void * desc): op_rnn(desc){}
+op_rnn_miopen::~op_rnn_miopen() {}
+
+void op_rnn_miopen::tune_op(){}
+void op_rnn_miopen::forward(){}
+void op_rnn_miopen::backward_data(){}
+void op_rnn_miopen::backward_filter(){}
+void op_rnn_miopen::backward(){}
+
+std::string op_rnn_miopen::get_fwd_algo_name() { return ""; }
+std::string op_rnn_miopen::get_bwd_data_name() { return ""; }
+std::string op_rnn_miopen::get_bwd_filter_name() { return ""; }
+
+void op_rnn_miopen::print_fwd_time(const float kernel_average_time) {}
+void op_rnn_miopen::print_bwd_time(const float kernel_average_time) {}
+void op_rnn_miopen::print_wrw_time(const float kernel_average_time) {}

--- a/src/backend/operator.cc
+++ b/src/backend/operator.cc
@@ -28,6 +28,7 @@ operator_base * operator_create(device_base *device, operator_type op_type, void
     operator_base * op = nullptr;
     switch(op_type){
         DISPATCH_OP(OP_CONV, op_convolution)
+        DISPATCH_OP(OP_RNN, op_rnn)
         IGNORE_OP(OP_POOLING, op_pooling)
         IGNORE_OP(OP_ACTIVATION, op_activation)
     }

--- a/src/backend/operator.hpp
+++ b/src/backend/operator.hpp
@@ -257,11 +257,22 @@ public:
 
 class op_rnn : public operator_base{
 public:
-    op_rnn(void * desc)
+    op_rnn(void * desc) :
+        rnn(NULL),
+        rnnfp16(NULL),
+        timeForward(0.0),
+        timeBackwardData(0.0),
+        timeBackwardWeights(0.0)
     {
         rnn_desc = (rnn_desc_t*)desc;
     }
-    ~op_rnn() {}
+    ~op_rnn()
+    {
+        if (rnn != NULL)
+            delete rnn;
+        if (rnnfp16 != NULL)
+            delete rnnfp16;
+    }
 
     virtual void forward();
     virtual void backward();
@@ -280,6 +291,10 @@ public:
 
     RNN_IMPL<float>* rnn;
     RNN_IMPL<half>* rnnfp16;
+
+    float timeForward;
+    float timeBackwardData;
+    float timeBackwardWeights;
 
     // data type (0-FP32, 2-FP16)
     cudnnDataType_t dataType;

--- a/src/backend/rnn.h
+++ b/src/backend/rnn.h
@@ -560,22 +560,26 @@ void RNN_IMPL<T>::validate()
     if (error & OUTPUT_SIZE)        std::cout << "outputSize must be less then or equal to the hiddenSize." << std::endl;
     if (error != 0) exit(error);
 
-    print_info("Arguments");
-    print_info("seqLength", seqLength);
-    print_info("numLayers", numLayers);
-    print_info("inputSize", inputSize);
-    print_info("hiddenSize", hiddenSize);
-    print_info("outputSize", outputSize);
-    print_info("miniBatch", miniBatch);
-    print_info("rnnInputMode", rnnInputMode, to_str(rnnInputMode));
-    print_info("recurrencePattern", recurrencePattern, to_str(recurrencePattern));
-    print_info("rnnCellMode", rnnCellMode, to_str(rnnCellMode));
-    print_info("rnnBiasMode", rnnBiasMode, to_str(rnnBiasMode));
-    print_info("rnnAlgorithm", rnnAlgorithm, to_str(rnnAlgorithm));
-    print_info("mathPrecision", mathPrecision, to_str(mathPrecision));
-    print_info("mathType", mathType, to_str(mathType));
-    print_info("dataType", dataType, to_str(dataType));
-    print_info("dropout", dropout);
+    bool debug = false;
+    if (debug)
+    {
+        print_info("Arguments");
+        print_info("seqLength", seqLength);
+        print_info("numLayers", numLayers);
+        print_info("inputSize", inputSize);
+        print_info("hiddenSize", hiddenSize);
+        print_info("outputSize", outputSize);
+        print_info("miniBatch", miniBatch);
+        print_info("rnnInputMode", rnnInputMode, to_str(rnnInputMode));
+        print_info("recurrencePattern", recurrencePattern, to_str(recurrencePattern));
+        print_info("rnnCellMode", rnnCellMode, to_str(rnnCellMode));
+        print_info("rnnBiasMode", rnnBiasMode, to_str(rnnBiasMode));
+        print_info("rnnAlgorithm", rnnAlgorithm, to_str(rnnAlgorithm));
+        print_info("mathPrecision", mathPrecision, to_str(mathPrecision));
+        print_info("mathType", mathType, to_str(mathType));
+        print_info("dataType", dataType, to_str(dataType));
+        print_info("dropout", dropout);
+    }
 }
 
 // TODO run init before rnn execution, outside run(...)

--- a/src/backend/rnn.h
+++ b/src/backend/rnn.h
@@ -78,9 +78,9 @@ class RNN_IMPL {
     cudnnHandle_t cudnnHandle;
     cudnnRNNDescriptor_t rnnDesc;
 
-    cudnnRNNDataLayout_t rnnDataLayout = CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_PACKED;
-    cudnnForwardMode_t fwdMode = CUDNN_FWD_MODE_TRAINING;
-    cudnnWgradMode_t wgradMode = CUDNN_WGRAD_MODE_ADD;
+    cudnnRNNDataLayout_t rnnDataLayout;
+    cudnnForwardMode_t fwdMode;
+    cudnnWgradMode_t wgradMode;
 
     std::vector<int> seqLengthArray;
     int* devSeqLengthArray;

--- a/src/backend/rnn.h
+++ b/src/backend/rnn.h
@@ -1,0 +1,845 @@
+#ifndef __RNN_H
+#define __RNN_H
+
+#include <cudnn.h>
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime_api.h>
+#include <cstdio>
+#include <random>
+#include <string>
+#include <vector>
+#include <iostream>
+#include <iomanip>
+#include <algorithm>
+
+template <typename T>
+class RNN_IMPL {
+   public:
+    void *x;
+    void *hx;
+    void *cx;
+
+    void *dx;
+    void *dhx;
+    void *dcx;
+
+    void *y;
+    void *hy;
+    void *cy;
+
+    void *dy;
+    void *dhy;
+    void *dcy;
+
+    // data type (0-FP32, 2-FP16)
+    cudnnDataType_t dataType;
+    // math precision (0-FP32, 2-FP16)
+    cudnnDataType_t mathPrecision;
+    // math type (0-default, 1-tensor op math, 2-tensor op math with conversion)
+    cudnnMathType_t mathType;
+    // recurrence pattern (0-unidirectional, 1-bidirectional)
+    cudnnDirectionMode_t recurrencePattern;
+    // recurrence algorithm (0-standard, 1-persist static, 2-persist dynamics)
+    cudnnRNNAlgo_t rnnAlgorithm;
+    // bias mode (0-no bias, 1-inp bias, 2-double bias, 3-rec bias)
+    cudnnRNNBiasMode_t rnnBiasMode;
+    // cell type (0-RELU, 1-TANH, 2-LSTM, 3-GRU)
+    cudnnRNNMode_t rnnCellMode;
+    // input mode (0-linear input, 1-skip input)
+    cudnnRNNInputMode_t rnnInputMode;
+
+    // dropout rate
+    float dropout;
+    // hidden size
+    int hiddenSize;
+    // input vector size
+    int inputSize;
+    // max miniBatch size
+    int miniBatch;
+    // number of layers
+    int numLayers;
+    // LSTM cell output size after the recurrent projection
+    int outputSize;
+    // sequence length
+    int seqLength;
+
+    cudaEvent_t start;
+    cudaEvent_t stop;
+
+    // number of warm-up iterations
+    int warmupIterations;
+    // number of measurement iterations
+    int measureIterations;
+
+    std::mt19937 eng;
+    std::uniform_real_distribution<> dist;
+
+    cudnnHandle_t cudnnHandle;
+    cudnnRNNDescriptor_t rnnDesc;
+
+    cudnnRNNDataLayout_t rnnDataLayout = CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_PACKED;
+    cudnnForwardMode_t fwdMode = CUDNN_FWD_MODE_TRAINING;
+    cudnnWgradMode_t wgradMode = CUDNN_WGRAD_MODE_ADD;
+
+    std::vector<int> seqLengthArray;
+    int* devSeqLengthArray;
+
+    size_t weightSpaceSize;
+    size_t workSpaceSize;
+    size_t reserveSpaceSize;
+
+    void* weightSpace = NULL;
+    void* dweightSpace = NULL;
+    void* workSpace = NULL;
+    void* reserveSpace = NULL;
+
+    cudnnRNNDataDescriptor_t xDesc;
+    cudnnRNNDataDescriptor_t yDesc;
+
+    cudnnTensorDescriptor_t hDesc;
+    cudnnTensorDescriptor_t cDesc;
+
+    void* states;
+    cudnnDropoutDescriptor_t dropoutDesc;
+
+    RNN_IMPL<T>() :
+        x  (NULL),
+        hx (NULL),
+        cx (NULL),
+        dx (NULL),
+        dhx(NULL),
+        dcx(NULL),
+        y  (NULL),
+        hy (NULL),
+        cy (NULL),
+        dy (NULL),
+        dhy(NULL),
+        dcy(NULL),
+        start(NULL),
+        stop(NULL),
+        warmupIterations(3),
+        measureIterations(10),
+        cudnnHandle(NULL),
+        rnnDesc(NULL),
+        rnnDataLayout(CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_PACKED),
+        fwdMode(CUDNN_FWD_MODE_TRAINING),
+        wgradMode(CUDNN_WGRAD_MODE_ADD),
+        devSeqLengthArray(NULL),
+        weightSpaceSize(0),
+        workSpaceSize(0),
+        reserveSpaceSize(0),
+        weightSpace(NULL),
+        dweightSpace(NULL),
+        workSpace(NULL),
+        reserveSpace(NULL),
+        xDesc(NULL),
+        yDesc(NULL),
+        hDesc(NULL),
+        cDesc(NULL),
+        states(NULL),
+        dropoutDesc(NULL)
+        {
+            // init();
+        };
+
+    ~RNN_IMPL<T>()
+    {
+        cudnnDestroy(cudnnHandle);
+
+        cudaFree(x);
+        cudaFree(hx);
+        cudaFree(cx);
+        cudaFree(y);
+        cudaFree(hy);
+        cudaFree(cy);
+        cudaFree(dx);
+        cudaFree(dhx);
+        cudaFree(dcx);
+        cudaFree(dy);
+        cudaFree(dhy);
+        cudaFree(dcy);
+        cudaFree(workSpace);
+        cudaFree(reserveSpace);
+        cudaFree(weightSpace);
+        cudaFree(dweightSpace);
+        cudaFree(states);
+        cudaFree(devSeqLengthArray);
+
+        cudaEventDestroy(start);
+        cudaEventDestroy(stop);
+
+        cudnnDestroyRNNDataDescriptor(xDesc);
+        cudnnDestroyRNNDataDescriptor(yDesc);
+
+        cudnnDestroyTensorDescriptor(hDesc);
+        cudnnDestroyTensorDescriptor(cDesc);
+
+        cudnnDestroyDropoutDescriptor(dropoutDesc);
+        cudnnDestroyRNNDescriptor(rnnDesc);
+    }
+
+    // initialize the device memory with values from a uniform distribution between 0 and 1.
+    void real(void* dst, const size_t& size)
+    {
+        std::vector<T> values(size);
+
+        std::generate(values.begin(), values.end(), [&]{ return dist(eng); });
+
+        cudaMemcpy(dst, &values[0], size * sizeof(T), cudaMemcpyHostToDevice);
+    }
+
+    // initialize the device memory with 1.
+    void ones(void* dst, const size_t& size)
+    {
+        std::vector<T> values(size, 1.0);
+
+        cudaMemcpy(dst, &values[0], size * sizeof(T), cudaMemcpyHostToDevice);
+    }
+
+    void validate();
+
+    void init();
+
+    void run(float& timeForward,
+    float& timeBackwardData,
+    float& timeBackwardWeights);
+
+    float forward();
+    float backward_data();
+    float backward_filter();
+
+    enum errors_t
+    {
+        NO_ERROR           = 0,
+        DATA_TYPE          = 2^0,
+        MATH_PRECISION     = 2^1,
+        MATH_TYPE          = 2^2,
+        RECURRENCE_PATTERN = 2^3,
+        RNN_ALGORITHM      = 2^4,
+        RNN_BIAS_MODE      = 2^5,
+        RNN_CELL_MODE      = 2^6,
+        RNN_INPUT_MODE     = 2^7,
+        INPUT_SIZE         = 2^8,
+        OUTPUT_SIZE        = 2^9,
+    };
+
+    // data type (0-FP32, 2-FP16)
+    errors_t check(const cudnnDataType_t& dataType)
+    {
+        switch(dataType)
+        {
+            case CUDNN_DATA_FLOAT: return NO_ERROR;
+            case CUDNN_DATA_HALF:  return NO_ERROR;
+            default: return DATA_TYPE;
+        }
+    }
+
+    // math type (0-default, 1-tensor op math, 2-tensor op math with conversion)
+    errors_t check(const cudnnMathType_t& mathType)
+    {
+        switch(mathType)
+        {
+            case CUDNN_DEFAULT_MATH:                    return NO_ERROR;
+            case CUDNN_TENSOR_OP_MATH:                  return NO_ERROR;
+            case CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION: return NO_ERROR;
+            default: return MATH_TYPE;
+        }
+    }
+
+    // recurrence pattern (0-unidirectional, 1-bidirectional)
+    errors_t check(const cudnnDirectionMode_t& recurrencePattern)
+    {
+        switch(recurrencePattern)
+        {
+            case CUDNN_UNIDIRECTIONAL: return NO_ERROR;
+            case CUDNN_BIDIRECTIONAL:  return NO_ERROR;
+            default: return RECURRENCE_PATTERN;
+        }
+    }
+
+    // recurrence algorithm (0-standard, 1-persist static, 2-persist dynamics)
+    errors_t check(const cudnnRNNAlgo_t& rnnAlgorithm)
+    {
+        switch(rnnAlgorithm)
+        {
+            case CUDNN_RNN_ALGO_STANDARD:        return NO_ERROR;
+            case CUDNN_RNN_ALGO_PERSIST_STATIC:  return NO_ERROR;
+            case CUDNN_RNN_ALGO_PERSIST_DYNAMIC: return NO_ERROR;
+            default: return RNN_ALGORITHM;
+        }
+    }
+
+    // bias mode (0-no bias, 1-inp bias, 2-double bias, 3-rec bias)
+    errors_t check(const cudnnRNNBiasMode_t& rnnBiasMode)
+    {
+        switch(rnnBiasMode)
+        {
+            case CUDNN_RNN_NO_BIAS:         return NO_ERROR;
+            case CUDNN_RNN_SINGLE_INP_BIAS: return NO_ERROR;
+            case CUDNN_RNN_DOUBLE_BIAS:     return NO_ERROR;
+            case CUDNN_RNN_SINGLE_REC_BIAS: return NO_ERROR;
+            default: return RNN_BIAS_MODE;
+        }
+    }
+
+    // cell type (0-RELU, 1-TANH, 2-LSTM, 3-GRU)
+    errors_t check(const cudnnRNNMode_t& rnnCellMode)
+    {
+        switch(rnnCellMode)
+        {
+            case CUDNN_RNN_RELU: return NO_ERROR;
+            case CUDNN_RNN_TANH: return NO_ERROR;
+            case CUDNN_LSTM:     return NO_ERROR;
+            case CUDNN_GRU:      return NO_ERROR;
+            default: return RNN_CELL_MODE;
+        }
+    }
+
+    // input mode (0-linear input, 1-skip input)
+    errors_t check(const cudnnRNNInputMode_t& rnnInputMode)
+    {
+        switch(rnnInputMode)
+        {
+            case CUDNN_LINEAR_INPUT: return NO_ERROR;
+            case CUDNN_SKIP_INPUT:   return NO_ERROR;
+            default: return RNN_INPUT_MODE;
+        }
+    }
+
+    errors_t check(const cudnnDataType_t& dataType,
+        const cudnnDataType_t& mathPrecision)
+    {
+        switch(dataType)
+        {
+            case CUDNN_DATA_FLOAT:
+            {
+                switch(mathPrecision)
+                {
+                    case CUDNN_DATA_FLOAT: return NO_ERROR;
+                    default: return MATH_PRECISION;
+                }
+            }
+            case CUDNN_DATA_HALF:
+            {
+                switch(mathPrecision)
+                {
+                    case CUDNN_DATA_FLOAT: return NO_ERROR;
+                    case CUDNN_DATA_HALF:  return NO_ERROR;
+                    default: return MATH_PRECISION;
+                }
+            }
+            default: return NO_ERROR;
+        }
+    }
+
+    errors_t check(const cudnnDataType_t& dataType,
+        const cudnnMathType_t& mathType)
+    {
+        switch(dataType)
+        {
+            case CUDNN_DATA_FLOAT:
+            {
+                switch(mathType)
+                {
+                    case CUDNN_DEFAULT_MATH:                    return NO_ERROR;
+                    case CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION: return NO_ERROR;
+                    default: return MATH_TYPE;
+                }
+            }
+            default: return NO_ERROR;
+        }
+    }
+
+    errors_t check(const cudnnRNNInputMode_t& rnnInputMode,
+        const int& inputSize, const int& hiddenSize)
+    {
+        if (rnnInputMode != CUDNN_SKIP_INPUT) return NO_ERROR;
+        if (inputSize == hiddenSize)          return NO_ERROR;
+        return INPUT_SIZE;
+    }
+
+    errors_t check(const int& outputSize, const int& hiddenSize)
+    {
+        if (outputSize <= hiddenSize) return NO_ERROR;
+        return OUTPUT_SIZE;
+    }
+
+    // get cell mode from string
+    cudnnRNNMode_t get_cellMode(const std::string& input)
+    {
+        if (input == "relu")
+            return CUDNN_RNN_RELU;
+        if (input == "tanh")
+            return CUDNN_RNN_TANH;
+        if (input == "lstm")
+            return CUDNN_LSTM;
+        if (input == "gru")
+            return CUDNN_GRU;
+
+        // this seems to be the default value in MIOpenDriver
+        return CUDNN_RNN_TANH;
+    }
+
+    static int BidirectionalScale(const cudnnDirectionMode_t& recurrencePattern)
+    {
+        return (recurrencePattern == CUDNN_BIDIRECTIONAL ? 2 : 1);
+    };
+
+    static size_t InputTensorSize(const int& seqLength,
+        const int& miniBatch, const int& inputSize)
+    {
+        return seqLength * miniBatch * inputSize;
+    };
+
+    static size_t OutputTensorSize(const int& seqLength, const int& miniBatch,
+        const int& hiddenSize, const cudnnDirectionMode_t& recurrencePattern)
+    {
+        int bidirectionalScale = BidirectionalScale(recurrencePattern);
+        return seqLength * miniBatch * hiddenSize * bidirectionalScale;
+    };
+
+    static size_t HiddenTensorSize(const int& numLayers, const int& miniBatch,
+        const int& hiddenSize, const cudnnDirectionMode_t& recurrencePattern)
+    {
+        int bidirectionalScale = BidirectionalScale(recurrencePattern);
+        return numLayers * miniBatch * hiddenSize * bidirectionalScale;
+    };
+
+    static int NumLinearLayers(const cudnnRNNMode_t& rnnCellMode)
+    {
+        int output = 0;
+        if (rnnCellMode == CUDNN_RNN_RELU || rnnCellMode == CUDNN_RNN_TANH)
+        {
+            output = 2;
+        }
+        else if (rnnCellMode == CUDNN_LSTM)
+        {
+            output = 8;
+        }
+        else if (rnnCellMode == CUDNN_GRU)
+        {
+            output = 6;
+        }
+
+        return output;
+    };
+
+    static const char* to_str(const cudnnDataType_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_DATA_FLOAT:              return "CUDNN_DATA_FLOAT";
+            case CUDNN_DATA_DOUBLE:             return "CUDNN_DATA_DOUBLE";
+            case CUDNN_DATA_HALF:               return "CUDNN_DATA_HALF";
+            case CUDNN_DATA_INT8:               return "CUDNN_DATA_INT8";
+            case CUDNN_DATA_INT32:              return "CUDNN_DATA_INT32";
+            case CUDNN_DATA_INT8x4:             return "CUDNN_DATA_INT8x4";
+            case CUDNN_DATA_UINT8:              return "CUDNN_DATA_UINT8";
+            case CUDNN_DATA_UINT8x4:            return "CUDNN_DATA_UINT8x4";
+            case CUDNN_DATA_INT8x32:            return "CUDNN_DATA_INT8x32";
+            case CUDNN_DATA_BFLOAT16:           return "CUDNN_DATA_BFLOAT16";
+            case CUDNN_DATA_INT64:              return "CUDNN_DATA_INT64";
+            case CUDNN_DATA_BOOLEAN:            return "CUDNN_DATA_BOOLEAN";
+            case CUDNN_DATA_FP8_E4M3:           return "CUDNN_DATA_FP8_E4M3";
+            case CUDNN_DATA_FP8_E5M2:           return "CUDNN_DATA_FP8_E5M2";
+            case CUDNN_DATA_FAST_FLOAT_FOR_FP8: return "CUDNN_DATA_FAST_FLOAT_FOR_FP8";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static const char* to_str(const cudnnRNNInputMode_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_LINEAR_INPUT:            return "CUDNN_LINEAR_INPUT";
+            case CUDNN_SKIP_INPUT:              return "CUDNN_SKIP_INPUT";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static const char* to_str(const cudnnDirectionMode_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_UNIDIRECTIONAL:          return "CUDNN_LINEAR_INPUT";
+            case CUDNN_BIDIRECTIONAL:           return "CUDNN_SKIP_INPUT";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static const char* to_str(const cudnnRNNMode_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_RNN_RELU:                return "CUDNN_RNN_RELU";
+            case CUDNN_RNN_TANH:                return "CUDNN_RNN_TANH";
+            case CUDNN_LSTM:                    return "CUDNN_LSTM";
+            case CUDNN_GRU:                     return "CUDNN_GRU";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static const char* to_str(const cudnnRNNBiasMode_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_RNN_NO_BIAS:             return "CUDNN_RNN_NO_BIAS";
+            case CUDNN_RNN_SINGLE_INP_BIAS:     return "CUDNN_RNN_SINGLE_INP_BIAS";
+            case CUDNN_RNN_DOUBLE_BIAS:         return "CUDNN_RNN_DOUBLE_BIAS";
+            case CUDNN_RNN_SINGLE_REC_BIAS:     return "CUDNN_RNN_SINGLE_REC_BIAS";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static const char* to_str(const cudnnRNNAlgo_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_RNN_ALGO_STANDARD:               return "CUDNN_RNN_ALGO_STANDARD";
+            case CUDNN_RNN_ALGO_PERSIST_STATIC:         return "CUDNN_RNN_ALGO_PERSIST_STATIC";
+            case CUDNN_RNN_ALGO_PERSIST_DYNAMIC:        return "CUDNN_RNN_ALGO_PERSIST_DYNAMIC";
+            case CUDNN_RNN_ALGO_PERSIST_STATIC_SMALL_H: return "CUDNN_RNN_ALGO_PERSIST_STATIC_SMALL_H";
+            case CUDNN_RNN_ALGO_COUNT:                  return "CUDNN_RNN_ALGO_COUNT";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static const char* to_str(const cudnnMathType_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_DEFAULT_MATH:                    return "CUDNN_DEFAULT_MATH";
+            case CUDNN_TENSOR_OP_MATH:                  return "CUDNN_TENSOR_OP_MATH";
+            case CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION: return "CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION";
+            case CUDNN_FMA_MATH:                        return "CUDNN_FMA_MATH";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static void print_info(const std::string& str1,
+    const double& value = -1.0, const std::string& str2 = "")
+    {
+        std::cout << std::right << std::setw(20) << str1  << ": ";
+        if (value != -1)
+        {
+            std::cout << std::right << std::setw(8) << std::setprecision(4) << value << " ";
+            std::cout << std::left  << std::setw(30) << str2  << " ";
+        }
+        std::cout << std::endl;
+    }
+};
+
+template <typename T>
+void RNN_IMPL<T>::validate()
+{
+    int error = 0;
+    error |= check(dataType);
+    error |= check(dataType, mathPrecision);
+    error |= check(dataType, mathType);
+    // error |= check(mathPrecision);
+    // error |= check(mathType);
+    error |= check(recurrencePattern);
+    error |= check(rnnAlgorithm);
+    error |= check(rnnBiasMode);
+    error |= check(rnnCellMode);
+    error |= check(rnnInputMode);
+    error |= check(rnnInputMode, inputSize, hiddenSize);
+    error |= check(outputSize, hiddenSize);
+
+
+    if (error & DATA_TYPE)          std::cout << "dataType must be 0 (FP32) or 2 (FP16), as in cudnnDataType_t." << std::endl;
+    if (error & MATH_PRECISION)     std::cout << "mathPrecision does not match dataType." << std::endl;
+    if (error & MATH_TYPE)          std::cout << "mathType does not match dataType." << std::endl;
+    if (error & RECURRENCE_PATTERN) std::cout << "recurrencePattern must be 0 (unidirectional) or  1 (bidirectional), as in cudnnDirectionMode_t." << std::endl;
+    if (error & RNN_ALGORITHM)      std::cout << "rnnAlgorithm  must be 0 (standard), 1 (persist static) or 2 (persist dynamics), as in cudnnRNNAlgo_t." << std::endl;
+    if (error & RNN_BIAS_MODE)      std::cout << "rnnBiasMode must be 0 (no bias), 1 (inp bias), 2 (double bias) or  3 (rec bias), as in cudnnRNNBiasMode_t." << std::endl;
+    if (error & RNN_CELL_MODE)      std::cout << "rnnCellMode must be 0 (RELU), 1 (TANH), 2 (LSTM) or 3 (GRU), as in cudnnRNNMode_t." << std::endl;
+    if (error & RNN_INPUT_MODE)     std::cout << "input mode 0 (linear input) or 1 (skip input), as in cudnnRNNInputMode_t." << std::endl;
+    if (error & INPUT_SIZE)         std::cout << "inputSize must be equal to hiddenSize." << std::endl;
+    if (error & OUTPUT_SIZE)        std::cout << "outputSize must be less then or equal to the hiddenSize." << std::endl;
+    if (error != 0) exit(error);
+
+    print_info("Arguments");
+    print_info("seqLength", seqLength);
+    print_info("numLayers", numLayers);
+    print_info("inputSize", inputSize);
+    print_info("hiddenSize", hiddenSize);
+    print_info("outputSize", outputSize);
+    print_info("miniBatch", miniBatch);
+    print_info("rnnInputMode", rnnInputMode, to_str(rnnInputMode));
+    print_info("recurrencePattern", recurrencePattern, to_str(recurrencePattern));
+    print_info("rnnCellMode", rnnCellMode, to_str(rnnCellMode));
+    print_info("rnnBiasMode", rnnBiasMode, to_str(rnnBiasMode));
+    print_info("rnnAlgorithm", rnnAlgorithm, to_str(rnnAlgorithm));
+    print_info("mathPrecision", mathPrecision, to_str(mathPrecision));
+    print_info("mathType", mathType, to_str(mathType));
+    print_info("dataType", dataType, to_str(dataType));
+    print_info("dropout", dropout);
+}
+
+// TODO run init before rnn execution, outside run(...)
+template <typename T>
+void RNN_IMPL<T>::init()
+{
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    std::seed_seq seed_seq{0};
+    eng = std::mt19937{seed_seq};
+    dist = std::uniform_real_distribution<>(0, 1);
+
+    // create cudnn context
+    cudnnCreate(&cudnnHandle);
+
+    // create rnn descriptor
+    cudnnCreateRNNDescriptor(&rnnDesc);
+
+    int bidirectionalScale = BidirectionalScale(recurrencePattern);
+    size_t inputTensorSize  = InputTensorSize(seqLength, miniBatch, inputSize);
+    size_t outputTensorSize = OutputTensorSize(seqLength, miniBatch,
+        hiddenSize, recurrencePattern);
+    size_t hiddenTensorSize = HiddenTensorSize(numLayers, miniBatch,
+        hiddenSize, recurrencePattern);
+    int numLinearLayers = NumLinearLayers(rnnCellMode);
+
+    // Dimensions for hidden state tensors
+    int dimHidden[3] = {numLayers * bidirectionalScale, miniBatch, hiddenSize};
+    int strideHidden[3] = {dimHidden[1] * dimHidden[2], dimHidden[2], 1};
+
+    T paddingFill = 0.0;
+
+    // // Dropout descriptor parameters
+    unsigned long long seed = 1337ull;
+    size_t stateSize;
+
+    // TODO: absolutely need to make sure this is initialized before most everything else
+    // Memory allocation for seqLengthArray on the host and device
+    seqLengthArray = std::vector<int>(miniBatch);
+    for (int i = 0; i < miniBatch; i++)
+        seqLengthArray[i] = seqLength;
+    cudaMalloc((void**)&devSeqLengthArray, miniBatch * sizeof(int));
+    cudaMemcpy(devSeqLengthArray, &seqLengthArray[0], miniBatch * sizeof(int),
+        cudaMemcpyHostToDevice);
+
+    // Memory allocation. hx, cx, dhx, dcx, hy, cy, dhy and dcy can be NULL.
+    cudaMalloc((void**)&x,  inputTensorSize  * sizeof(T));
+    cudaMalloc((void**)&y,  outputTensorSize * sizeof(T));
+    cudaMalloc((void**)&dx, inputTensorSize  * sizeof(T));
+    cudaMalloc((void**)&dy, outputTensorSize * sizeof(T));
+
+    cudaMalloc((void**)&hx,  hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&cx,  hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&hy,  hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&cy,  hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&dhx, hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&dcx, hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&dhy, hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&dcy, hiddenTensorSize * sizeof(T));
+
+    // create/set RNN x data descriptors
+    cudnnCreateRNNDataDescriptor(&xDesc);
+    cudnnSetRNNDataDescriptor(xDesc, dataType, rnnDataLayout, seqLength,
+        miniBatch, inputSize, &seqLengthArray[0], &paddingFill);
+
+    // create/set RNN y data descriptors
+    cudnnCreateRNNDataDescriptor(&yDesc);
+    cudnnSetRNNDataDescriptor(yDesc, dataType, rnnDataLayout, seqLength,
+        miniBatch, hiddenSize * bidirectionalScale, &seqLengthArray[0], &paddingFill);
+
+    cudnnCreateTensorDescriptor(&hDesc);
+    cudnnSetTensorNdDescriptor(hDesc, dataType, 3, dimHidden, strideHidden);
+
+    cudnnCreateTensorDescriptor(&cDesc);
+    cudnnSetTensorNdDescriptor(cDesc, dataType, 3, dimHidden, strideHidden);
+
+    // Set up the dropout descriptor (needed for the RNN descriptor)
+    cudnnCreateDropoutDescriptor(&dropoutDesc);
+    cudnnDropoutGetStatesSize(cudnnHandle, &stateSize);
+    cudaMalloc(&states, stateSize);
+    cudnnSetDropoutDescriptor(dropoutDesc, cudnnHandle, dropout, states,
+        stateSize, seed);
+
+    // Set up the RNN descriptor
+    cudnnSetRNNDescriptor_v8(rnnDesc, rnnAlgorithm, rnnCellMode, rnnBiasMode,
+        recurrencePattern, rnnInputMode, dataType, mathPrecision, mathType,
+        inputSize, hiddenSize, outputSize, numLayers, dropoutDesc, 0);
+
+    // Set up weights and bias parameters
+    cudnnGetRNNWeightSpaceSize(cudnnHandle, rnnDesc, &weightSpaceSize);
+    cudaMalloc((void**)&weightSpace, weightSpaceSize);
+    cudaMalloc((void**)&dweightSpace, weightSpaceSize);
+
+    // Set up work space and reserved memory
+    cudnnGetRNNTempSpaceSizes(cudnnHandle, rnnDesc, fwdMode, xDesc,
+        &workSpaceSize, &reserveSpaceSize);
+    cudaMalloc((void**)&workSpace, workSpaceSize);
+    cudaMalloc((void**)&reserveSpace, reserveSpaceSize);
+
+    // dynamic persistent RNN plan
+    if (rnnAlgorithm == CUDNN_RNN_ALGO_PERSIST_DYNAMIC)
+        cudnnBuildRNNDynamic(cudnnHandle, rnnDesc, miniBatch);
+
+    // Initialize inputs
+    ones(x, inputTensorSize);
+    ones(hx, hiddenTensorSize);
+    ones(cx, hiddenTensorSize);
+    ones(dy, outputTensorSize);
+    ones(dhy, hiddenTensorSize);
+    ones(dcy, hiddenTensorSize);
+
+    // initialize weights
+    cudnnTensorDescriptor_t wDesc;
+    cudnnTensorDescriptor_t bDesc;
+
+    cudnnCreateTensorDescriptor(&wDesc);
+    cudnnCreateTensorDescriptor(&bDesc);
+
+    for (int layer = 0; layer < numLayers * bidirectionalScale; layer++)
+    {
+        for (int linLayerID = 0; linLayerID < numLinearLayers; linLayerID++)
+        {
+            cudnnDataType_t dataTypeTemp;
+            int nbDims = 0;
+            int dim[3], stride[3];
+            T* linLayerMat  = NULL;
+            T* linLayerBias = NULL;
+
+            cudnnGetRNNWeightParams(cudnnHandle, rnnDesc, layer,
+                weightSpaceSize, weightSpace, linLayerID, wDesc,
+                (void**)&linLayerMat, bDesc, (void**)&linLayerBias);
+
+            if (linLayerMat)
+            {
+                // initialize using a uniform real distribution betwen 0 and 1
+                cudnnGetTensorNdDescriptor(wDesc, 3, &dataTypeTemp, &nbDims,
+                    dim, stride);
+                real(linLayerMat, dim[0] * dim[1] * dim[2]);
+            }
+
+            if (linLayerBias)
+            {
+                // initialize with 1.0
+                cudnnGetTensorNdDescriptor(bDesc, 3, &dataTypeTemp, &nbDims,
+                    dim, stride);
+                ones(linLayerBias, dim[0] * dim[1] * dim[2]);
+            }
+        }
+    }
+
+    cudnnDestroyTensorDescriptor(wDesc);
+    cudnnDestroyTensorDescriptor(bDesc);
+}
+
+template <typename T>
+void RNN_IMPL<T>::run(float& timeForward,
+    float& timeBackwardData,
+    float& timeBackwardWeights)
+{
+    timeForward = forward();
+    timeBackwardData = backward_data();
+    timeBackwardWeights = backward_filter();
+}
+
+template <typename T>
+float RNN_IMPL<T>::forward()
+{
+    float timeForward = 0.0;
+
+    cudaDeviceSynchronize();
+
+    for (int i = 0; i < warmupIterations; i++)
+    {
+        cudnnRNNForward(cudnnHandle, rnnDesc, fwdMode, devSeqLengthArray,
+            xDesc, x, yDesc, y, hDesc, hx, hy, cDesc, cx, cy, weightSpaceSize,
+            weightSpace, workSpaceSize, workSpace, reserveSpaceSize,
+            reserveSpace);
+    }
+
+    cudaEventRecord(start);
+    for (int i = 0; i < measureIterations; i++)
+    {
+        cudnnRNNForward(cudnnHandle, rnnDesc, fwdMode, devSeqLengthArray,
+            xDesc, x, yDesc, y, hDesc, hx, hy, cDesc, cx, cy, weightSpaceSize,
+            weightSpace, workSpaceSize, workSpace, reserveSpaceSize,
+            reserveSpace);
+    }
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+    cudaEventElapsedTime(&timeForward, start, stop);
+    timeForward /= measureIterations;
+
+    cudaDeviceSynchronize();
+
+    return timeForward;
+}
+
+template <typename T>
+float RNN_IMPL<T>::backward_data()
+{
+    float timeBackwardData = 0.0;
+
+    cudaDeviceSynchronize();
+
+    for (int i = 0; i < warmupIterations; i++)
+    {
+        cudnnRNNBackwardData_v8(cudnnHandle, rnnDesc, devSeqLengthArray, yDesc,
+            y, dy, xDesc, dx, hDesc, hx, dhy, dhx, cDesc, cx, dcy, dcx,
+            weightSpaceSize, weightSpace, workSpaceSize, workSpace,
+            reserveSpaceSize, reserveSpace);
+    }
+
+    cudaEventRecord(start);
+    for (int i = 0; i < measureIterations; i++)
+    {
+        cudnnRNNBackwardData_v8(cudnnHandle, rnnDesc, devSeqLengthArray, yDesc,
+            y, dy, xDesc, dx, hDesc, hx, dhy, dhx, cDesc, cx, dcy, dcx,
+            weightSpaceSize, weightSpace, workSpaceSize, workSpace,
+            reserveSpaceSize, reserveSpace);
+    }
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+    cudaEventElapsedTime(&timeBackwardData, start, stop);
+    timeBackwardData /= measureIterations;
+
+    cudaDeviceSynchronize();
+
+    return timeBackwardData;
+}
+
+template <typename T>
+float RNN_IMPL<T>::backward_filter()
+{
+    float timeBackwardWeights = 0.0;
+
+    cudaMemset(dweightSpace, 0, weightSpaceSize);
+
+    cudaDeviceSynchronize();
+
+    for (int i = 0; i < warmupIterations; i++)
+    {
+        cudnnRNNBackwardWeights_v8(cudnnHandle, rnnDesc, wgradMode,
+            devSeqLengthArray, xDesc, x, hDesc, hx, yDesc, y, weightSpaceSize,
+            dweightSpace, workSpaceSize, workSpace, reserveSpaceSize,
+            reserveSpace);
+    }
+
+    cudaEventRecord(start);
+    for (int i = 0; i < measureIterations; i++)
+    {
+        cudnnRNNBackwardWeights_v8(cudnnHandle, rnnDesc, wgradMode,
+            devSeqLengthArray, xDesc, x, hDesc, hx, yDesc, y, weightSpaceSize,
+            dweightSpace, workSpaceSize, workSpace, reserveSpaceSize,
+            reserveSpace);
+    }
+    cudaEventRecord(stop);
+    cudaEventSynchronize(stop);
+    cudaEventElapsedTime(&timeBackwardWeights, start, stop);
+    timeBackwardWeights /= measureIterations;
+
+    cudaDeviceSynchronize();
+
+    return timeBackwardWeights;
+}
+
+#endif

--- a/src/backend/rnn_clean.h
+++ b/src/backend/rnn_clean.h
@@ -1,0 +1,857 @@
+#ifndef __RNN_H
+#define __RNN_H
+
+#include <cudnn.h>
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime_api.h>
+#include <cstdio>
+#include <random>
+#include <string>
+#include <vector>
+#include <iostream>
+#include <iomanip>
+#include <algorithm>
+
+template <typename T>
+class RNN_IMPL {
+   public:
+    void *x;
+    void *hx;
+    void *cx;
+
+    void *dx;
+    void *dhx;
+    void *dcx;
+
+    void *y;
+    void *hy;
+    void *cy;
+
+    void *dy;
+    void *dhy;
+    void *dcy;
+
+    // data type (0-FP32, 2-FP16)
+    cudnnDataType_t dataType;
+    // math precision (0-FP32, 2-FP16)
+    cudnnDataType_t mathPrecision;
+    // math type (0-default, 1-tensor op math, 2-tensor op math with conversion)
+    cudnnMathType_t mathType;
+    // recurrence pattern (0-unidirectional, 1-bidirectional)
+    cudnnDirectionMode_t recurrencePattern;
+    // recurrence algorithm (0-standard, 1-persist static, 2-persist dynamics)
+    cudnnRNNAlgo_t rnnAlgorithm;
+    // bias mode (0-no bias, 1-inp bias, 2-double bias, 3-rec bias)
+    cudnnRNNBiasMode_t rnnBiasMode;
+    // cell type (0-RELU, 1-TANH, 2-LSTM, 3-GRU)
+    cudnnRNNMode_t rnnCellMode;
+    // input mode (0-linear input, 1-skip input)
+    cudnnRNNInputMode_t rnnInputMode;
+
+    // dropout rate
+    float dropout;
+    // hidden size
+    int hiddenSize;
+    // input vector size
+    int inputSize;
+    // max miniBatch size
+    int miniBatch;
+    // number of layers
+    int numLayers;
+    // LSTM cell output size after the recurrent projection
+    int outputSize;
+    // sequence length
+    int seqLength;
+
+
+    // number of warm-up iterations
+    int warmupIterations;
+    // number of measurement iterations
+    int measureIterations;
+
+    std::mt19937 eng;
+    std::uniform_real_distribution<> dist;
+
+    cudnnHandle_t cudnnHandle;
+    cudnnRNNDescriptor_t rnnDesc;
+
+    cudnnRNNDataLayout_t rnnDataLayout = CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_PACKED;
+    cudnnForwardMode_t fwdMode = CUDNN_FWD_MODE_TRAINING;
+    cudnnWgradMode_t wgradMode = CUDNN_WGRAD_MODE_ADD;
+
+    std::vector<int> seqLengthArray;
+    int* devSeqLengthArray;
+
+    size_t weightSpaceSize;
+    size_t workSpaceSize;
+    size_t reserveSpaceSize;
+
+    void* weightSpace = NULL;
+    void* dweightSpace = NULL;
+    void* workSpace = NULL;
+    void* reserveSpace = NULL;
+
+    RNN_IMPL<T>() :
+        x  (NULL),
+        hx (NULL),
+        cx (NULL),
+        dx (NULL),
+        dhx(NULL),
+        dcx(NULL),
+        y  (NULL),
+        hy (NULL),
+        cy (NULL),
+        dy (NULL),
+        dhy(NULL),
+        dcy(NULL),
+        warmupIterations(3),
+        measureIterations(10),
+        cudnnHandle(NULL),
+        rnnDesc(NULL),
+        rnnDataLayout(CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_PACKED),
+        fwdMode(CUDNN_FWD_MODE_TRAINING),
+        wgradMode(CUDNN_WGRAD_MODE_ADD),
+        devSeqLengthArray(NULL),
+        weightSpace(NULL),
+        dweightSpace(NULL),
+        workSpace(NULL),
+        reserveSpace(NULL)
+        {
+            std::seed_seq seed{0};
+            eng = std::mt19937{seed};
+            dist = std::uniform_real_distribution<>(0, 1);
+
+            // create cudnn context
+            cudnnCreate(&cudnnHandle);
+
+            // create rnn descriptor
+            cudnnCreateRNNDescriptor(&rnnDesc);
+        };
+
+    ~RNN_IMPL<T>()
+    {
+        cudnnDestroy(cudnnHandle);
+    }
+
+    // initialize the device memory with values from a uniform distribution between 0 and 1.
+    void real(void* dst, const size_t& size)
+    {
+        std::vector<T> values(size);
+
+        std::generate(values.begin(), values.end(), [&]{ return dist(eng); });
+
+        cudaMemcpy(dst, &values[0], size * sizeof(T), cudaMemcpyHostToDevice);
+    }
+
+    // initialize the device memory with 1.
+    void ones(void* dst, const size_t& size)
+    {
+        std::vector<T> values(size, 1.0);
+
+        cudaMemcpy(dst, &values[0], size * sizeof(T), cudaMemcpyHostToDevice);
+    }
+
+    void validate();
+
+    void init();
+
+    void run(float& timeForward,
+    float& timeBackwardData,
+    float& timeBackwardWeights);
+
+    float forward();
+    float backward_data();
+    float backward_filter();
+
+    enum errors_t
+    {
+        NO_ERROR           = 0,
+        DATA_TYPE          = 2^0,
+        MATH_PRECISION     = 2^1,
+        MATH_TYPE          = 2^2,
+        RECURRENCE_PATTERN = 2^3,
+        RNN_ALGORITHM      = 2^4,
+        RNN_BIAS_MODE      = 2^5,
+        RNN_CELL_MODE      = 2^6,
+        RNN_INPUT_MODE     = 2^7,
+        INPUT_SIZE         = 2^8,
+        OUTPUT_SIZE        = 2^9,
+    };
+
+    // data type (0-FP32, 2-FP16)
+    errors_t check(const cudnnDataType_t& dataType)
+    {
+        switch(dataType)
+        {
+            case CUDNN_DATA_FLOAT: return NO_ERROR;
+            case CUDNN_DATA_HALF:  return NO_ERROR;
+            default: return DATA_TYPE;
+        }
+    }
+
+    // math type (0-default, 1-tensor op math, 2-tensor op math with conversion)
+    errors_t check(const cudnnMathType_t& mathType)
+    {
+        switch(mathType)
+        {
+            case CUDNN_DEFAULT_MATH:                    return NO_ERROR;
+            case CUDNN_TENSOR_OP_MATH:                  return NO_ERROR;
+            case CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION: return NO_ERROR;
+            default: return MATH_TYPE;
+        }
+    }
+
+    // recurrence pattern (0-unidirectional, 1-bidirectional)
+    errors_t check(const cudnnDirectionMode_t& recurrencePattern)
+    {
+        switch(recurrencePattern)
+        {
+            case CUDNN_UNIDIRECTIONAL: return NO_ERROR;
+            case CUDNN_BIDIRECTIONAL:  return NO_ERROR;
+            default: return RECURRENCE_PATTERN;
+        }
+    }
+
+    // recurrence algorithm (0-standard, 1-persist static, 2-persist dynamics)
+    errors_t check(const cudnnRNNAlgo_t& rnnAlgorithm)
+    {
+        switch(rnnAlgorithm)
+        {
+            case CUDNN_RNN_ALGO_STANDARD:        return NO_ERROR;
+            case CUDNN_RNN_ALGO_PERSIST_STATIC:  return NO_ERROR;
+            case CUDNN_RNN_ALGO_PERSIST_DYNAMIC: return NO_ERROR;
+            default: return RNN_ALGORITHM;
+        }
+    }
+
+    // bias mode (0-no bias, 1-inp bias, 2-double bias, 3-rec bias)
+    errors_t check(const cudnnRNNBiasMode_t& rnnBiasMode)
+    {
+        switch(rnnBiasMode)
+        {
+            case CUDNN_RNN_NO_BIAS:         return NO_ERROR;
+            case CUDNN_RNN_SINGLE_INP_BIAS: return NO_ERROR;
+            case CUDNN_RNN_DOUBLE_BIAS:     return NO_ERROR;
+            case CUDNN_RNN_SINGLE_REC_BIAS: return NO_ERROR;
+            default: return RNN_BIAS_MODE;
+        }
+    }
+
+    // cell type (0-RELU, 1-TANH, 2-LSTM, 3-GRU)
+    errors_t check(const cudnnRNNMode_t& rnnCellMode)
+    {
+        switch(rnnCellMode)
+        {
+            case CUDNN_RNN_RELU: return NO_ERROR;
+            case CUDNN_RNN_TANH: return NO_ERROR;
+            case CUDNN_LSTM:     return NO_ERROR;
+            case CUDNN_GRU:      return NO_ERROR;
+            default: return RNN_CELL_MODE;
+        }
+    }
+
+    // input mode (0-linear input, 1-skip input)
+    errors_t check(const cudnnRNNInputMode_t& rnnInputMode)
+    {
+        switch(rnnInputMode)
+        {
+            case CUDNN_LINEAR_INPUT: return NO_ERROR;
+            case CUDNN_SKIP_INPUT:   return NO_ERROR;
+            default: return RNN_INPUT_MODE;
+        }
+    }
+
+    errors_t check(const cudnnDataType_t& dataType,
+        const cudnnDataType_t& mathPrecision)
+    {
+        switch(dataType)
+        {
+            case CUDNN_DATA_FLOAT:
+            {
+                switch(mathPrecision)
+                {
+                    case CUDNN_DATA_FLOAT: return NO_ERROR;
+                    default: return MATH_PRECISION;
+                }
+            }
+            case CUDNN_DATA_HALF:
+            {
+                switch(mathPrecision)
+                {
+                    case CUDNN_DATA_FLOAT: return NO_ERROR;
+                    case CUDNN_DATA_HALF:  return NO_ERROR;
+                    default: return MATH_PRECISION;
+                }
+            }
+            default: return NO_ERROR;
+        }
+    }
+
+    errors_t check(const cudnnDataType_t& dataType,
+        const cudnnMathType_t& mathType)
+    {
+        switch(dataType)
+        {
+            case CUDNN_DATA_FLOAT:
+            {
+                switch(mathType)
+                {
+                    case CUDNN_DEFAULT_MATH:                    return NO_ERROR;
+                    case CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION: return NO_ERROR;
+                    default: return MATH_TYPE;
+                }
+            }
+            default: return NO_ERROR;
+        }
+    }
+
+    errors_t check(const cudnnRNNInputMode_t& rnnInputMode,
+        const int& inputSize, const int& hiddenSize)
+    {
+        if (rnnInputMode != CUDNN_SKIP_INPUT) return NO_ERROR;
+        if (inputSize == hiddenSize)          return NO_ERROR;
+        return INPUT_SIZE;
+    }
+
+    errors_t check(const int& outputSize, const int& hiddenSize)
+    {
+        if (outputSize <= hiddenSize) return NO_ERROR;
+        return OUTPUT_SIZE;
+    }
+
+    // get cell mode from string
+    cudnnRNNMode_t get_cellMode(const std::string& input)
+    {
+        if (input == "relu")
+            return CUDNN_RNN_RELU;
+        if (input == "tanh")
+            return CUDNN_RNN_TANH;
+        if (input == "lstm")
+            return CUDNN_LSTM;
+        if (input == "gru")
+            return CUDNN_GRU;
+
+        // this seems to be the default value in MIOpenDriver
+        return CUDNN_RNN_TANH;
+    }
+
+    static int BidirectionalScale(const cudnnDirectionMode_t& recurrencePattern)
+    {
+        return (recurrencePattern == CUDNN_BIDIRECTIONAL ? 2 : 1);
+    };
+
+    static size_t InputTensorSize(const int& seqLength,
+        const int& miniBatch, const int& inputSize)
+    {
+        return seqLength * miniBatch * inputSize;
+    };
+
+    static size_t OutputTensorSize(const int& seqLength, const int& miniBatch,
+        const int& hiddenSize, const cudnnDirectionMode_t& recurrencePattern)
+    {
+        int bidirectionalScale = BidirectionalScale(recurrencePattern);
+        return seqLength * miniBatch * hiddenSize * bidirectionalScale;
+    };
+
+    static size_t HiddenTensorSize(const int& numLayers, const int& miniBatch,
+        const int& hiddenSize, const cudnnDirectionMode_t& recurrencePattern)
+    {
+        int bidirectionalScale = BidirectionalScale(recurrencePattern);
+        return numLayers * miniBatch * hiddenSize * bidirectionalScale;
+    };
+
+    static int NumLinearLayers(const cudnnRNNMode_t& rnnCellMode)
+    {
+        int output = 0;
+        if (rnnCellMode == CUDNN_RNN_RELU || rnnCellMode == CUDNN_RNN_TANH)
+        {
+            output = 2;
+        }
+        else if (rnnCellMode == CUDNN_LSTM)
+        {
+            output = 8;
+        }
+        else if (rnnCellMode == CUDNN_GRU)
+        {
+            output = 6;
+        }
+
+        return output;
+    };
+
+    static const char* to_str(const cudnnDataType_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_DATA_FLOAT:              return "CUDNN_DATA_FLOAT";
+            case CUDNN_DATA_DOUBLE:             return "CUDNN_DATA_DOUBLE";
+            case CUDNN_DATA_HALF:               return "CUDNN_DATA_HALF";
+            case CUDNN_DATA_INT8:               return "CUDNN_DATA_INT8";
+            case CUDNN_DATA_INT32:              return "CUDNN_DATA_INT32";
+            case CUDNN_DATA_INT8x4:             return "CUDNN_DATA_INT8x4";
+            case CUDNN_DATA_UINT8:              return "CUDNN_DATA_UINT8";
+            case CUDNN_DATA_UINT8x4:            return "CUDNN_DATA_UINT8x4";
+            case CUDNN_DATA_INT8x32:            return "CUDNN_DATA_INT8x32";
+            case CUDNN_DATA_BFLOAT16:           return "CUDNN_DATA_BFLOAT16";
+            case CUDNN_DATA_INT64:              return "CUDNN_DATA_INT64";
+            case CUDNN_DATA_BOOLEAN:            return "CUDNN_DATA_BOOLEAN";
+            case CUDNN_DATA_FP8_E4M3:           return "CUDNN_DATA_FP8_E4M3";
+            case CUDNN_DATA_FP8_E5M2:           return "CUDNN_DATA_FP8_E5M2";
+            case CUDNN_DATA_FAST_FLOAT_FOR_FP8: return "CUDNN_DATA_FAST_FLOAT_FOR_FP8";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static const char* to_str(const cudnnRNNInputMode_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_LINEAR_INPUT:            return "CUDNN_LINEAR_INPUT";
+            case CUDNN_SKIP_INPUT:              return "CUDNN_SKIP_INPUT";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static const char* to_str(const cudnnDirectionMode_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_UNIDIRECTIONAL:          return "CUDNN_LINEAR_INPUT";
+            case CUDNN_BIDIRECTIONAL:           return "CUDNN_SKIP_INPUT";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static const char* to_str(const cudnnRNNMode_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_RNN_RELU:                return "CUDNN_RNN_RELU";
+            case CUDNN_RNN_TANH:                return "CUDNN_RNN_TANH";
+            case CUDNN_LSTM:                    return "CUDNN_LSTM";
+            case CUDNN_GRU:                     return "CUDNN_GRU";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static const char* to_str(const cudnnRNNBiasMode_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_RNN_NO_BIAS:             return "CUDNN_RNN_NO_BIAS";
+            case CUDNN_RNN_SINGLE_INP_BIAS:     return "CUDNN_RNN_SINGLE_INP_BIAS";
+            case CUDNN_RNN_DOUBLE_BIAS:         return "CUDNN_RNN_DOUBLE_BIAS";
+            case CUDNN_RNN_SINGLE_REC_BIAS:     return "CUDNN_RNN_SINGLE_REC_BIAS";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static const char* to_str(const cudnnRNNAlgo_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_RNN_ALGO_STANDARD:               return "CUDNN_RNN_ALGO_STANDARD";
+            case CUDNN_RNN_ALGO_PERSIST_STATIC:         return "CUDNN_RNN_ALGO_PERSIST_STATIC";
+            case CUDNN_RNN_ALGO_PERSIST_DYNAMIC:        return "CUDNN_RNN_ALGO_PERSIST_DYNAMIC";
+            case CUDNN_RNN_ALGO_PERSIST_STATIC_SMALL_H: return "CUDNN_RNN_ALGO_PERSIST_STATIC_SMALL_H";
+            case CUDNN_RNN_ALGO_COUNT:                  return "CUDNN_RNN_ALGO_COUNT";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static const char* to_str(const cudnnMathType_t& value)
+    {
+        switch(value)
+        {
+            case CUDNN_DEFAULT_MATH:                    return "CUDNN_DEFAULT_MATH";
+            case CUDNN_TENSOR_OP_MATH:                  return "CUDNN_TENSOR_OP_MATH";
+            case CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION: return "CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION";
+            case CUDNN_FMA_MATH:                        return "CUDNN_FMA_MATH";
+            default: return "UNDEFINED";
+        }
+    }
+
+    static void print_info(const std::string& str1,
+    const double& value = -1.0, const std::string& str2 = "")
+    {
+        std::cout << std::right << std::setw(20) << str1  << ": ";
+        if (value != -1)
+        {
+            std::cout << std::right << std::setw(8) << std::setprecision(4) << value << " ";
+            std::cout << std::left  << std::setw(30) << str2  << " ";
+        }
+        std::cout << std::endl;
+    }
+};
+
+template <typename T>
+void RNN_IMPL<T>::validate()
+{
+    int error = 0;
+    error |= check(dataType);
+    error |= check(dataType, mathPrecision);
+    error |= check(dataType, mathType);
+    // error |= check(mathPrecision);
+    // error |= check(mathType);
+    error |= check(recurrencePattern);
+    error |= check(rnnAlgorithm);
+    error |= check(rnnBiasMode);
+    error |= check(rnnCellMode);
+    error |= check(rnnInputMode);
+    error |= check(rnnInputMode, inputSize, hiddenSize);
+    error |= check(outputSize, hiddenSize);
+
+
+    if (error & DATA_TYPE)          std::cout << "dataType must be 0 (FP32) or 2 (FP16), as in cudnnDataType_t." << std::endl;
+    if (error & MATH_PRECISION)     std::cout << "mathPrecision does not match dataType." << std::endl;
+    if (error & MATH_TYPE)          std::cout << "mathType does not match dataType." << std::endl;
+    if (error & RECURRENCE_PATTERN) std::cout << "recurrencePattern must be 0 (unidirectional) or  1 (bidirectional), as in cudnnDirectionMode_t." << std::endl;
+    if (error & RNN_ALGORITHM)      std::cout << "rnnAlgorithm  must be 0 (standard), 1 (persist static) or 2 (persist dynamics), as in cudnnRNNAlgo_t." << std::endl;
+    if (error & RNN_BIAS_MODE)      std::cout << "rnnBiasMode must be 0 (no bias), 1 (inp bias), 2 (double bias) or  3 (rec bias), as in cudnnRNNBiasMode_t." << std::endl;
+    if (error & RNN_CELL_MODE)      std::cout << "rnnCellMode must be 0 (RELU), 1 (TANH), 2 (LSTM) or 3 (GRU), as in cudnnRNNMode_t." << std::endl;
+    if (error & RNN_INPUT_MODE)     std::cout << "input mode 0 (linear input) or 1 (skip input), as in cudnnRNNInputMode_t." << std::endl;
+    if (error & INPUT_SIZE)         std::cout << "inputSize must be equal to hiddenSize." << std::endl;
+    if (error & OUTPUT_SIZE)        std::cout << "outputSize must be less then or equal to the hiddenSize." << std::endl;
+    if (error != 0) exit(error);
+
+    print_info("Arguments");
+    print_info("seqLength", seqLength);
+    print_info("numLayers", numLayers);
+    print_info("inputSize", inputSize);
+    print_info("hiddenSize", hiddenSize);
+    print_info("outputSize", outputSize);
+    print_info("miniBatch", miniBatch);
+    print_info("rnnInputMode", rnnInputMode, to_str(rnnInputMode));
+    print_info("recurrencePattern", recurrencePattern, to_str(recurrencePattern));
+    print_info("rnnCellMode", rnnCellMode, to_str(rnnCellMode));
+    print_info("rnnBiasMode", rnnBiasMode, to_str(rnnBiasMode));
+    print_info("rnnAlgorithm", rnnAlgorithm, to_str(rnnAlgorithm));
+    print_info("mathPrecision", mathPrecision, to_str(mathPrecision));
+    print_info("mathType", mathType, to_str(mathType));
+    print_info("dataType", dataType, to_str(dataType));
+    print_info("dropout", dropout);
+}
+
+// TODO run init before rnn execution, outside run(...)
+template <typename T>
+void RNN_IMPL<T>::init()
+{
+    int bidirectionalScale = BidirectionalScale(recurrencePattern);
+    size_t inputTensorSize  = InputTensorSize(seqLength, miniBatch, inputSize);
+    size_t outputTensorSize = OutputTensorSize(seqLength, miniBatch,
+        hiddenSize, recurrencePattern);
+    size_t hiddenTensorSize = HiddenTensorSize(numLayers, miniBatch,
+        hiddenSize, recurrencePattern);
+    int numLinearLayers = NumLinearLayers(rnnCellMode);
+
+    // TODO: absolutely need to make sure this is initialized before most everything else
+    // Memory allocation for seqLengthArray on the host and device
+    seqLengthArray = std::vector<int>(miniBatch);
+    int* devSeqLengthArray = NULL;
+    for (int i = 0; i < miniBatch; i++)
+        seqLengthArray[i] = seqLength;
+    cudaMalloc((void**)&devSeqLengthArray, miniBatch * sizeof(int));
+    cudaMemcpy(devSeqLengthArray, &seqLengthArray[0], miniBatch * sizeof(int),
+        cudaMemcpyHostToDevice);
+
+    // Initialize inputs
+    ones(x, inputTensorSize);
+    ones(hx, hiddenTensorSize);
+    ones(cx, hiddenTensorSize);
+    ones(dy, outputTensorSize);
+    ones(dhy, hiddenTensorSize);
+    ones(dcy, hiddenTensorSize);
+
+    // initialize weights
+    cudnnTensorDescriptor_t wDesc;
+    cudnnTensorDescriptor_t bDesc;
+
+    cudnnCreateTensorDescriptor(&wDesc);
+    cudnnCreateTensorDescriptor(&bDesc);
+
+    for (int layer = 0; layer < numLayers * bidirectionalScale; layer++)
+    {
+        for (int linLayerID = 0; linLayerID < numLinearLayers; linLayerID++)
+        {
+            cudnnDataType_t dataTypeTemp;
+            int nbDims = 0;
+            int dim[3], stride[3];
+            T* linLayerMat  = NULL;
+            T* linLayerBias = NULL;
+
+            cudnnGetRNNWeightParams(cudnnHandle, rnnDesc, layer,
+                weightSpaceSize, weightSpace, linLayerID, wDesc,
+                (void**)&linLayerMat, bDesc, (void**)&linLayerBias);
+
+            if (linLayerMat)
+            {
+                // initialize using a uniform real distribution betwen 0 and 1
+                cudnnGetTensorNdDescriptor(wDesc, 3, &dataTypeTemp, &nbDims,
+                    dim, stride);
+                real(linLayerMat, dim[0] * dim[1] * dim[2]);
+            }
+
+            if (linLayerBias)
+            {
+                // initialize with 1.0
+                cudnnGetTensorNdDescriptor(bDesc, 3, &dataTypeTemp, &nbDims,
+                    dim, stride);
+                ones(linLayerBias, dim[0] * dim[1] * dim[2]);
+            }
+        }
+    }
+
+    cudnnDestroyTensorDescriptor(wDesc);
+    cudnnDestroyTensorDescriptor(bDesc);
+}
+
+template <typename T>
+void RNN_IMPL<T>::run(float& timeForward,
+    float& timeBackwardData,
+    float& timeBackwardWeights)
+{
+    // Dimensions for hidden state tensors
+    int bidirectionalScale = BidirectionalScale(recurrencePattern);
+    int dimHidden[3] = {numLayers * bidirectionalScale, miniBatch, hiddenSize};
+    int strideHidden[3] = {dimHidden[1] * dimHidden[2], dimHidden[2], 1};
+
+    size_t inputTensorSize = InputTensorSize(seqLength, miniBatch, inputSize);
+    size_t outputTensorSize = OutputTensorSize(seqLength, miniBatch,
+        hiddenSize, recurrencePattern);
+    size_t hiddenTensorSize = HiddenTensorSize(numLayers, miniBatch,
+        hiddenSize, recurrencePattern);
+
+    T paddingFill = 0.0;
+
+    // Dropout descriptor parameters
+    unsigned long long seed = 1337ull;
+    size_t stateSize;
+    void* states = NULL;
+
+    // Profiling parameters
+    cudaEvent_t start;
+    cudaEvent_t stop;
+
+    cudnnRNNDataDescriptor_t xDesc = NULL;
+    cudnnRNNDataDescriptor_t yDesc = NULL;
+
+    cudnnTensorDescriptor_t hDesc = NULL;
+    cudnnTensorDescriptor_t cDesc = NULL;
+
+    cudnnDropoutDescriptor_t dropoutDesc = NULL;
+
+    // Initialize all the data
+    init();
+
+    // Memory allocation. hx, cx, dhx, dcx, hy, cy, dhy and dcy can be NULL.
+    cudaMalloc((void**)&x,  inputTensorSize  * sizeof(T));
+    cudaMalloc((void**)&y,  outputTensorSize * sizeof(T));
+    cudaMalloc((void**)&dx, inputTensorSize  * sizeof(T));
+    cudaMalloc((void**)&dy, outputTensorSize * sizeof(T));
+
+    cudaMalloc((void**)&hx,  hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&cx,  hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&hy,  hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&cy,  hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&dhx, hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&dcx, hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&dhy, hiddenTensorSize * sizeof(T));
+    cudaMalloc((void**)&dcy, hiddenTensorSize * sizeof(T));
+
+    // create/set RNN x data descriptors
+    cudnnCreateRNNDataDescriptor(&xDesc);
+    cudnnSetRNNDataDescriptor(xDesc, dataType, rnnDataLayout, seqLength,
+        miniBatch, inputSize, &seqLengthArray[0], &paddingFill);
+
+    // create/set RNN y data descriptors
+    cudnnCreateRNNDataDescriptor(&yDesc);
+    cudnnSetRNNDataDescriptor(yDesc, dataType, rnnDataLayout, seqLength,
+        miniBatch, hiddenSize * bidirectionalScale, &seqLengthArray[0], &paddingFill);
+
+    cudnnCreateTensorDescriptor(&hDesc);
+    cudnnSetTensorNdDescriptor(hDesc, dataType, 3, dimHidden, strideHidden);
+
+    cudnnCreateTensorDescriptor(&cDesc);
+    cudnnSetTensorNdDescriptor(cDesc, dataType, 3, dimHidden, strideHidden);
+
+    // Set up the dropout descriptor (needed for the RNN descriptor)
+    cudnnCreateDropoutDescriptor(&dropoutDesc);
+    cudnnDropoutGetStatesSize(cudnnHandle, &stateSize);
+    cudaMalloc(&states, stateSize);
+    cudnnSetDropoutDescriptor(dropoutDesc, cudnnHandle, dropout, states,
+        stateSize, seed);
+
+    // Set up the RNN descriptor
+    cudnnSetRNNDescriptor_v8(rnnDesc, rnnAlgorithm, rnnCellMode, rnnBiasMode,
+        recurrencePattern, rnnInputMode, dataType, mathPrecision, mathType,
+        inputSize, hiddenSize, outputSize, numLayers, dropoutDesc, 0);
+
+    // Set up weights and bias parameters
+    cudnnGetRNNWeightSpaceSize(cudnnHandle, rnnDesc, &weightSpaceSize);
+    cudaMalloc((void**)&weightSpace, weightSpaceSize);
+    cudaMalloc((void**)&dweightSpace, weightSpaceSize);
+
+    // Set up work space and reserved memory
+    cudnnGetRNNTempSpaceSizes(cudnnHandle, rnnDesc, fwdMode, xDesc,
+        &workSpaceSize, &reserveSpaceSize);
+    cudaMalloc((void**)&workSpace, workSpaceSize);
+    cudaMalloc((void**)&reserveSpace, reserveSpaceSize);
+
+    // dynamic persistent RNN plan
+    if (rnnAlgorithm == CUDNN_RNN_ALGO_PERSIST_DYNAMIC)
+        cudnnBuildRNNDynamic(cudnnHandle, rnnDesc, miniBatch);
+
+    cudaDeviceSynchronize();
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    // timeForward = forward();
+    for (int i = 0; i < warmupIterations + measureIterations; i++)
+    {
+        float elapsedTime = 0.0;
+        cudaEventRecord(start);
+
+        cudnnRNNForward(cudnnHandle, rnnDesc, fwdMode, devSeqLengthArray,
+            xDesc, x, yDesc, y, hDesc, hx, hy, cDesc, cx, cy, weightSpaceSize,
+            weightSpace, workSpaceSize, workSpace, reserveSpaceSize,
+            reserveSpace);
+
+        cudaEventRecord(stop);
+        cudaEventSynchronize(stop);
+        cudaEventElapsedTime(&timeForward, start, stop);
+
+        if (i > warmupIterations)
+            timeForward += elapsedTime;
+    }
+    timeForward /= measureIterations;
+
+    // backward data
+    for (int i = 0; i < warmupIterations + measureIterations; i++)
+    {
+        float elapsedTime = 0.0;
+        cudaEventRecord(start);
+
+        cudnnRNNBackwardData_v8(cudnnHandle, rnnDesc, devSeqLengthArray, yDesc,
+            y, dy, xDesc, dx, hDesc, hx, dhy, dhx, cDesc, cx, dcy, dcx,
+            weightSpaceSize, weightSpace, workSpaceSize, workSpace,
+            reserveSpaceSize, reserveSpace);
+
+        cudaEventRecord(stop);
+        cudaEventSynchronize(stop);
+        cudaEventElapsedTime(&timeBackwardData, start, stop);
+
+        if (i > warmupIterations)
+            timeBackwardData += elapsedTime;
+    }
+    timeBackwardData /= measureIterations;
+
+    // backward weights
+    for (int i = 0; i < warmupIterations + measureIterations; i++)
+    {
+        float elapsedTime = 0.0;
+
+        cudaEventRecord(start);
+
+        cudaMemset(dweightSpace, 0, weightSpaceSize);
+
+        cudnnRNNBackwardWeights_v8(cudnnHandle, rnnDesc, wgradMode,
+            devSeqLengthArray, xDesc, x, hDesc, hx, yDesc, y, weightSpaceSize,
+            dweightSpace, workSpaceSize, workSpace, reserveSpaceSize,
+            reserveSpace);
+
+        cudaEventRecord(stop);
+        cudaEventSynchronize(stop);
+        cudaEventElapsedTime(&timeBackwardWeights, start, stop);
+
+        if (i > warmupIterations)
+            timeBackwardWeights += elapsedTime;
+    }
+    timeBackwardWeights /= measureIterations;
+
+    cudaDeviceSynchronize();
+
+    // clean-up
+    cudaFree(x);
+    cudaFree(hx);
+    cudaFree(cx);
+    cudaFree(y);
+    cudaFree(hy);
+    cudaFree(cy);
+    cudaFree(dx);
+    cudaFree(dhx);
+    cudaFree(dcx);
+    cudaFree(dy);
+    cudaFree(dhy);
+    cudaFree(dcy);
+    cudaFree(workSpace);
+    cudaFree(reserveSpace);
+    cudaFree(weightSpace);
+    cudaFree(dweightSpace);
+    cudaFree(states);
+    cudaFree(devSeqLengthArray);
+
+    cudnnDestroyRNNDataDescriptor(xDesc);
+    cudnnDestroyRNNDataDescriptor(yDesc);
+
+    cudnnDestroyTensorDescriptor(hDesc);
+    cudnnDestroyTensorDescriptor(cDesc);
+
+    cudnnDestroyDropoutDescriptor(dropoutDesc);
+    cudnnDestroyRNNDescriptor(rnnDesc);
+
+}
+
+template <typename T>
+float RNN_IMPL<T>::forward()
+{
+    float timeForwrd = 0.0;
+
+    // cudaEvent_t start;
+    // cudaEvent_t stop;
+
+    // cudaEventCreate(&start);
+    // cudaEventCreate(&stop);
+
+    // for (int i = 0; i < warmupIterations + measureIterations; i++)
+    // {
+    //     float elapsedTime = 0.0;
+    //     cudaEventRecord(start);
+
+    //     cudnnRNNForward(cudnnHandle, rnnDesc, fwdMode, devSeqLengthArray,
+    //         xDesc, x, yDesc, y, hDesc, hx, hy, cDesc, cx, cy, weightSpaceSize,
+    //         weightSpace, workSpaceSize, workSpace, reserveSpaceSize,
+    //         reserveSpace);
+
+    //     cudaEventRecord(stop);
+    //     cudaEventSynchronize(stop);
+    //     cudaEventElapsedTime(&timeForward, start, stop);
+
+    //     if (i > warmupIterations)
+    //         timeForward += elapsedTime;
+    // }
+    // timeForward /= measureIterations;
+
+    // cudaEventDestroy(start);
+    // cudaEventDestroy(stop);
+
+    return timeForwrd;
+}
+
+template <typename T>
+float RNN_IMPL<T>::backward_data()
+{
+    float timeBackwardData = 0.0;
+
+    return timeBackwardData;
+}
+
+template <typename T>
+float RNN_IMPL<T>::backward_filter()
+{
+    float timeBackwardWeights = 0.0;
+
+    return timeBackwardWeights;
+}
+
+#endif

--- a/src/executable/op_driver.cc
+++ b/src/executable/op_driver.cc
@@ -1298,8 +1298,6 @@ static int rnn_driver(int argc, char ** argv){
     ((op_rnn*)rnn_base)->warmupIterations    = num_warmup;
     ((op_rnn*)rnn_base)->measureIterations   = num_iterations;
 
-    // device_timer_t * dt = gpu_dev->device_timer_create();
-
     rnn_base->tune_op();
 
     if (is_fwd) {
@@ -1323,8 +1321,7 @@ static int rnn_driver(int argc, char ** argv){
             rnn_base->print_wrw_time(((op_rnn*)rnn_base)->timeBackwardWeights);
     }
 
-    // clean
-    // gpu_dev->device_timer_destroy(dt);
+    // clean-up
     operator_destroy(rnn_base);
     gpu_dev->rnn_desc_destroy(rnn_desc);
 

--- a/test.sh
+++ b/test.sh
@@ -3,10 +3,10 @@
 ./rebuild.sh
 echo
 
-echo ./build/op_driver rnn -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 1 -t 1 -w 1
-./build/op_driver rnn     -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 1 -t 1 -w 1
+echo './build/op_driver rnn     -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 0 -t 1 -w 1'
+./build/op_driver rnn     -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 0 -t 1 -w 1
 echo
 
-echo ./build/op_driver rnnfp16 -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 1 -t 1 -w 1
-./build/op_driver rnnfp16 -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 1 -t 1 -w 1
+echo './build/op_driver rnnfp16 -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 0 -t 1 -w 1'
+./build/op_driver rnnfp16 -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 0 -t 1 -w 1
 echo

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+./rebuild.sh
+echo
+
+echo ./build/op_driver rnn -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 1 -t 1 -w 1
+./build/op_driver rnn     -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 1 -t 1 -w 1
+echo
+
+echo ./build/op_driver rnnfp16 -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 1 -t 1 -w 1
+./build/op_driver rnnfp16 -n 224 -W 224 -H 1000 -l 8 -b 1 -m lstm -p 0 -r 0 -k 32 -c 0 -F 1 -t 1 -w 1
+echo


### PR DESCRIPTION
`[miopen_cudnn_ops is DEPRECATED and will be soon removed entirely]`
`[please use miopen_cudnn_ops_private instead.]`

Added RNN support targeting CUDNN.

Disclaimer:

- there's no path for miOpen; this shouldn't be a problem since MIOpenDriver already supports RNN ops.
- didn't follow the exact same code pattern as the existing code for convolution support.
- there are some differences between cuDNN and miOpen; as such there was some guesswork involved in matching MIOpenDriver command line arguments to cuDNN APIs.
- there's some possibility that the implementation is incorrect in some way; will need someone with both miOpen and cuDNN expertise to verify.